### PR TITLE
[FE] webpack merge 적용하여 중복 제거

### DIFF
--- a/FE/package.json
+++ b/FE/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --env=dev --profile --colors --open",
-    "build": "webpack --env=prod",
+    "start": "webpack-dev-server --open --config webpack.dev.js",
+    "build": "webpack --config webpack.prod.js",
     "lint": "eslint src/** --ext .ts,.tsx --no-error-on-unmatched-pattern",
     "lint:fix": "yarn lint --fix"
   },
@@ -46,6 +46,7 @@
     "ts-loader": "^7.0.4",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.11.0"
+    "webpack-dev-server": "^3.11.0",
+    "webpack-merge": "^4.2.2"
   }
 }

--- a/FE/webpack.common.js
+++ b/FE/webpack.common.js
@@ -1,0 +1,37 @@
+const path = require("path");
+const webpack = require("webpack");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+
+module.exports = {
+  entry: "./src/index.jsx",
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: ["babel-loader", "ts-loader"],
+      },
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-env"],
+        },
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    alias: {
+      Components: path.resolve(__dirname, "./src/components/"),
+      Styles: path.resolve(__dirname, "./src/styles/"),
+    },
+    extensions: [".js", ".jsx", ".ts", ".tsx"],
+  },
+  plugins: [
+    new webpack.HotModuleReplacementPlugin(),
+    new HtmlWebpackPlugin({
+      filename: "index.html",
+      template: "public/index.html",
+    }),
+  ],
+};

--- a/FE/webpack.config.js
+++ b/FE/webpack.config.js
@@ -1,3 +1,0 @@
-module.exports = function (env) {
-  return require(`./webpack.${env}.js`);
-};

--- a/FE/webpack.dev.js
+++ b/FE/webpack.dev.js
@@ -1,10 +1,8 @@
-const path = require("path");
-const webpack = require("webpack");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
+const merge = require("webpack-merge");
+const common = require("./webpack.common.js");
 
-module.exports = {
+module.exports = merge(common, {
   mode: "development",
-  entry: "./src/index.jsx",
   devServer: {
     historyApiFallback: true,
     inline: true,
@@ -12,34 +10,4 @@ module.exports = {
     hot: true,
     publicPath: "/",
   },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: ["babel-loader", "ts-loader"],
-      },
-      {
-        test: /\.jsx?$/,
-        loader: "babel-loader",
-        options: {
-          presets: ["@babel/preset-env"],
-        },
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  resolve: {
-    alias: {
-      Components: path.resolve(__dirname, "./src/components/"),
-      Styles: path.resolve(__dirname, "./src/styles/"),
-    },
-    extensions: [".js", ".jsx", ".ts", ".tsx"],
-  },
-  plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new HtmlWebpackPlugin({
-      filename: "index.html",
-      template: "public/index.html",
-    }),
-  ],
-};
+});

--- a/FE/webpack.prod.js
+++ b/FE/webpack.prod.js
@@ -1,38 +1,6 @@
-const path = require("path");
-const webpack = require("webpack");
-const HtmlWebpackPlugin = require("html-webpack-plugin");
+const merge = require("webpack-merge");
+const common = require("./webpack.common.js");
 
-module.exports = {
+module.exports = merge(common, {
   mode: "production",
-  entry: "./src/index.jsx",
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: ["babel-loader", "ts-loader"],
-      },
-      {
-        test: /\.jsx$/,
-        loader: "babel-loader",
-        options: {
-          presets: ["@babel/preset-env"],
-        },
-        exclude: /node_modules/,
-      },
-    ],
-  },
-  resolve: {
-    alias: {
-      Components: path.resolve(__dirname, "./src/components/"),
-      Styles: path.resolve(__dirname, "./src/styles/"),
-    },
-    extensions: [".js", ".jsx", ".ts", ".tsx"],
-  },
-  plugins: [
-    new webpack.HotModuleReplacementPlugin(),
-    new HtmlWebpackPlugin({
-      filename: "index.html",
-      template: "public/index.html",
-    }),
-  ],
-};
+});

--- a/FE/yarn.lock
+++ b/FE/yarn.lock
@@ -6660,6 +6660,13 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-merge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
+  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+  dependencies:
+    lodash "^4.17.15"
+
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"


### PR DESCRIPTION
- 기존에 webpack mode routing을 담당하던 webpack.config.js 제거
- webpack.common.js를 생성하여 dev mode와 prod mode에서 동일하게 사용되는 코드를 모아둠
- `webpack-merge` 라이브러리의 merge 메소드를 사용하여 dev mode, prod mode 설정과 webpack.common의 설정을 merge

---

Close #15 
