### PR TITLE
[BE] listing API 구현

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -20,16 +20,21 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-//	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'mysql:mysql-connector-java'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-
+	compile group: 'org.mybatis.spring.boot', name: 'mybatis-spring-boot-starter', version: '2.1.2'
+//	compile group: 'org.mybatis', name: 'mybatis-spring', version: '2.0.4'
+//	compile group: 'org.mybatis', name: 'mybatis', version: '3.5.4'
+	testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.5.2'
+	testCompile group: 'org.assertj', name: 'assertj-core', version: '3.15.0'
+	implementation 'org.assertj:assertj-core:3.11.1'
 }
 
 test {

--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -27,7 +27,6 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}
-//	compile group: 'org.projectlombok', name: 'lombok', version: '1.18.8'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 

--- a/BE/src/main/java/kr/codesquad/airbnb09/Airbnb09Application.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/Airbnb09Application.java
@@ -1,13 +1,14 @@
 package kr.codesquad.airbnb09;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@MapperScan("kr.codesquad.airbnb09.service")
 public class Airbnb09Application {
 
 	public static void main(String[] args) {
 		SpringApplication.run(Airbnb09Application.class, args);
 	}
-
 }

--- a/BE/src/main/java/kr/codesquad/airbnb09/domain/AccommodationDTO.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/domain/AccommodationDTO.java
@@ -1,0 +1,19 @@
+package kr.codesquad.airbnb09.domain;
+
+import lombok.*;
+
+@Data
+public class AccommodationDTO {
+    private Long id;
+    private String title;
+    private int price;
+    private int discountPrice;
+    private int cleaningFee;
+    private int serviceFee;
+    private String country;
+    private double rating;
+    private boolean isSuperhost;
+    private int accommodates;
+    private double latitude;
+    private double longitude;
+}

--- a/BE/src/main/java/kr/codesquad/airbnb09/domain/ListingDAO.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/domain/ListingDAO.java
@@ -1,0 +1,17 @@
+package kr.codesquad.airbnb09.domain;
+
+import org.apache.ibatis.session.SqlSession;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ListingDAO {
+    private final SqlSession sqlSession;
+
+    public ListingDAO(SqlSession sqlSession) {
+        this.sqlSession = sqlSession;
+    }
+
+    public AccommodationDTO selectAccommodationById(long id) {
+        return this.sqlSession.selectOne("selectAccommodationById", id);
+    }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb09/mock/MockController.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/mock/MockController.java
@@ -14,13 +14,13 @@ public class MockController {
     private static final Logger log = LoggerFactory.getLogger(MockController.class);
 
     @GetMapping()
-    public List<MockInitResponseDto> initData() {
+    public List<MockInitResponseDTO> initData() {
         List<String> thumbnails = new ArrayList<>();
-        MockOneNightRateDto oneNightRateDto1 = new MockOneNightRateDto("59,000", "52,000");
-        MockOneNightRateDto oneNightRateDto2 = new MockOneNightRateDto("170,000", "163,000");
+        MockOneNightRateDTO oneNightRateDto1 = new MockOneNightRateDTO("59,000", "52,000");
+        MockOneNightRateDTO oneNightRateDto2 = new MockOneNightRateDTO("170,000", "163,000");
         thumbnails.add("https://i.imgur.com/KX9w8fC.jpg");
         thumbnails.add("https://a2.muscache.com/im/pictures/c0842db1-ee98-4fe8-870b-d1e2af33855d.jpg?aki_policy=x_large");
-        MockInitResponseDto mockInitResponseDto1 = MockInitResponseDto.builder()
+        MockInitResponseDTO mockInitResponseDto1 = MockInitResponseDTO.builder()
                 .id(11)
                 .name("Sunny Bungalow in the City")
                 .country("United States")
@@ -30,7 +30,7 @@ public class MockController {
                 .oneNightRate(oneNightRateDto1)
                 .build();
 
-        MockInitResponseDto mockInitResponseDto2 = MockInitResponseDto.builder()
+        MockInitResponseDTO mockInitResponseDto2 = MockInitResponseDTO.builder()
                 .id(12)
                 .name("Charming room in pet friendly apt")
                 .country("United States")
@@ -41,36 +41,36 @@ public class MockController {
                 .build();
 
 
-        List<MockInitResponseDto> mockInitResponseDtos = new ArrayList<>();
+        List<MockInitResponseDTO> mockInitResponseDtos = new ArrayList<>();
         mockInitResponseDtos.add(mockInitResponseDto1);
         mockInitResponseDtos.add(mockInitResponseDto2);
         return mockInitResponseDtos;
     }
 
     @GetMapping("/search")
-    public List<MockInitResponseDto> mockSearchData(@RequestParam Map<String, String> params) {
+    public List<MockInitResponseDTO> mockSearchData(@RequestParam Map<String, String> params) {
         log.debug("checkin : {}, checkout : {}, adults : {}, children : {}, infants : {}, priceMin : {}, priceMax : {}",
                 params.get("checkin"), params.get("checkout"), params.get("adults"), params.get("children"), params.get("infants"),
                 params.get("priceMin"), params.get("priceMax"));
         List<String> thumbnails = new ArrayList<>();
-        MockOneNightRateDto oneNightRateDto1 = new MockOneNightRateDto("59,000", "52,000");
-        MockOneNightRateDto oneNightRateDto2 = new MockOneNightRateDto("170,000", "163,000");
+        MockOneNightRateDTO oneNightRateDto1 = new MockOneNightRateDTO("59,000", "52,000");
+        MockOneNightRateDTO oneNightRateDto2 = new MockOneNightRateDTO("170,000", "163,000");
         thumbnails.add("https://i.imgur.com/KX9w8fC.jpg");
         thumbnails.add("https://a2.muscache.com/im/pictures/c0842db1-ee98-4fe8-870b-d1e2af33855d.jpg?aki_policy=x_large");
-        MockPriceDto priceDto1 = MockPriceDto.builder()
+        MockPriceDTO priceDto1 = MockPriceDTO.builder()
                 .accomdationRate("1,104,300")
                 .cleaningFee("42,945")
                 .serviceFee("600")
                 .totalPrice("1,147,845")
                 .build();
-        MockPriceDto priceDto2 = MockPriceDto.builder()
+        MockPriceDTO priceDto2 = MockPriceDTO.builder()
                 .accomdationRate("151,534")
                 .cleaningFee("12,270")
                 .serviceFee("1,200")
                 .totalPrice("165,004")
                 .build();
 
-        MockInitResponseDto mockInitResponseDto1 = MockInitResponseDto.builder()
+        MockInitResponseDTO mockInitResponseDto1 = MockInitResponseDTO.builder()
                 .id(11)
                 .name("Sunny Bungalow in the City")
                 .country("United States")
@@ -82,7 +82,7 @@ public class MockController {
                 .price(priceDto1)
                 .build();
 
-        MockInitResponseDto mockInitResponseDto2 = MockInitResponseDto.builder()
+        MockInitResponseDTO mockInitResponseDto2 = MockInitResponseDTO.builder()
                 .id(12)
                 .name("Charming room in pet friendly apt")
                 .country("United States")
@@ -95,7 +95,7 @@ public class MockController {
                 .build();
 
 
-        List<MockInitResponseDto> mockInitResponseDtos = new ArrayList<>();
+        List<MockInitResponseDTO> mockInitResponseDtos = new ArrayList<>();
         mockInitResponseDtos.add(mockInitResponseDto1);
         mockInitResponseDtos.add(mockInitResponseDto2);
         return mockInitResponseDtos;

--- a/BE/src/main/java/kr/codesquad/airbnb09/mock/MockInitResponseDto.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/mock/MockInitResponseDto.java
@@ -10,14 +10,14 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Getter
 @Builder
-public class MockInitResponseDto {
+public class MockInitResponseDTO {
     private long id;
     private String name;
     private String country;
     private double rating;
     private boolean isSuperHost;
     private List<String> thumbnails;
-    private MockOneNightRateDto oneNightRate;
+    private MockOneNightRateDTO oneNightRate;
     private int nights;
-    private MockPriceDto price;
+    private MockPriceDTO price;
 }

--- a/BE/src/main/java/kr/codesquad/airbnb09/mock/MockOneNightRateDto.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/mock/MockOneNightRateDto.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 @Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
-public class MockOneNightRateDto {
+public class MockOneNightRateDTO {
     private String original;
     private String selling;
 
     @Builder
-    public MockOneNightRateDto(String original, String selling) {
+    public MockOneNightRateDTO(String original, String selling) {
         this.original = original;
         this.selling = selling;
     }

--- a/BE/src/main/java/kr/codesquad/airbnb09/mock/MockPriceDto.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/mock/MockPriceDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class MockPriceDto {
+public class MockPriceDTO {
     private String accomdationRate;
     private String cleaningFee;
     private String serviceFee;

--- a/BE/src/main/java/kr/codesquad/airbnb09/mock/MockSearchRequestDTO.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/mock/MockSearchRequestDTO.java
@@ -1,12 +1,15 @@
 package kr.codesquad.airbnb09.mock;
 
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 @Getter
 @Setter
 @ToString
 @Builder
-public class MockSearchRequestDto {
+public class MockSearchRequestDTO {
     private String checkin;
     private String checkout;
     private int adults;

--- a/BE/src/main/java/kr/codesquad/airbnb09/service/ListingMapper.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/service/ListingMapper.java
@@ -1,0 +1,13 @@
+package kr.codesquad.airbnb09.service;
+
+
+import kr.codesquad.airbnb09.domain.AccommodationDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface ListingMapper {
+
+    List<AccommodationDTO> getAccommodationList();
+}

--- a/BE/src/main/java/kr/codesquad/airbnb09/web/ListingController.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/web/ListingController.java
@@ -1,0 +1,20 @@
+package kr.codesquad.airbnb09.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/listing")
+@RestController
+public class ListingController {
+
+    @GetMapping
+    public String initData() {
+        return "전체 목록";
+    }
+
+    @GetMapping("/search")
+    public String searchData() {
+        return "필터링한 목록";
+    }
+}

--- a/BE/src/main/java/kr/codesquad/airbnb09/web/ListingController.java
+++ b/BE/src/main/java/kr/codesquad/airbnb09/web/ListingController.java
@@ -1,16 +1,25 @@
 package kr.codesquad.airbnb09.web;
 
+import kr.codesquad.airbnb09.service.ListingMapper;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RequestMapping("/listing")
 @RestController
 public class ListingController {
 
+    private ListingMapper listingMapper;
+
+    public ListingController(ListingMapper listingMapper) {
+        this.listingMapper = listingMapper;
+    }
+
     @GetMapping
-    public String initData() {
-        return "전체 목록";
+    public List lookupAllData() {
+        return listingMapper.getAccommodationList();
     }
 
     @GetMapping("/search")

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -1,1 +1,12 @@
 logging.level.root=debug
+
+# MySQL 접속
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.initialization-mode=always
+spring.datasource.url=jdbc:mysql://localhost:3306/airbnb?useSSL=false&useLegacyDatetimeCode=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+#spring.datasource.url=jdbc:mysql://database-solar.ccjphiioz2kr.ap-northeast-2.rds.amazonaws.com:3306/airbnb?useSSL=false&useLegacyDatetimeCode=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+# SQL 스키마, 데이터 경로
+spring.datasource.data=classpath:schema.sql
+spring.datasource.username=root
+spring.datasource.password=password
+mybatis.config-location=classpath:mybatis-config.xml

--- a/BE/src/main/resources/mapper/listingMapper.xml
+++ b/BE/src/main/resources/mapper/listingMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<!-- Namespace를 통해 JAVA 클래스와 Annotation클래스와 동기 -->
+<mapper namespace="kr.codesquad.airbnb09.service.ListingMapper">
+
+    <!-- Sql id 설정 및 parameterType, resultType을 설정. -->
+    <select id="getAccommodationList" parameterType = "String" resultType="AccommodationDTO">
+        SELECT id, title, price, discount_price, cleaning_fee, service_fee, country, rating, is_superhost, accommodates, latitude, longitude FROM airbnb.listing LIMIT 500;
+    </select>
+</mapper>

--- a/BE/src/main/resources/mybatis-config.xml
+++ b/BE/src/main/resources/mybatis-config.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?> <!-- XML 문서의 유효성 체크를 위해 필요 -->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+
+    <typeAliases>
+        <package name="kr.codesquad.airbnb09.domain"/>
+    </typeAliases>
+    <!-- SQL 코드와 매핑 정의를 가지는 XML 파일인 mapper 의 목록을 지정한다. -->
+    <mappers>
+        <mapper resource="mapper/listingMapper.xml"/>
+    </mappers>
+</configuration>

--- a/BE/src/main/resources/schema.sql
+++ b/BE/src/main/resources/schema.sql
@@ -1,3 +1,4 @@
+SET foreign_key_checks = 0; # 외래키를 무시하고 지울 수 있도록 외래키 체크 설정을 off
 -- -----------------------------------------------------
 -- Schema airbnb
 -- -----------------------------------------------------
@@ -13,7 +14,7 @@ CREATE TABLE IF NOT EXISTS `airbnb`.`listing`
 (
     `id`             BIGINT      NOT NULL AUTO_INCREMENT,
     `title`          VARCHAR(64) NULL,
-    `price`          VARCHAR(64) NULL DEFAULT 0,
+    `price`          INT         NULL DEFAULT 0,
     `discount_price` INT         NULL,
     `cleaning_fee`   INT         NULL DEFAULT 0,
     `service_fee`    INT         NULL DEFAULT 0,

--- a/BE/src/test/java/kr/codesquad/airbnb09/mybatis/DBTest.java
+++ b/BE/src/test/java/kr/codesquad/airbnb09/mybatis/DBTest.java
@@ -1,0 +1,20 @@
+package kr.codesquad.airbnb09.mybatis;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.io.InputStream;
+
+@SpringBootTest
+public class DBTest {
+
+    @Test
+    public void SqlFactory에서_Session을_Build() {
+        //설정 정보의 InputStream을 받아온다.
+        String resource = "mybatis-config.xml";
+        InputStream inputStream = getClass().getResourceAsStream(resource);
+
+        //InputStream을 통해 설정 정보를 읽어서 SqlSessionFactory를 빌드한다.
+//        SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder()
+    }
+}


### PR DESCRIPTION
## listing API 구현

* MyBatis 적용
1. 의존성 추가
2. @MapperScan 어노테이션 추가
3. Mapper Interface 구현 - Mapper XML 파일에 정의한 쿼리와 매칭됨
4. DTO 생성 - 쿼리 실행결과를 담을 객체
5. Mapper XML 파일 생성
 - SQL 코드와 매핑 정의
 - 매핑할 Mapper 인터페이스를 namespace에 지정
 - 쿼리 작성 후, 해당 쿼리의 id값을 Mapper Interface에 선언해줘야 함
6. mybatis-config.xml 파일 생성
 - DTO 파일이 존재하는 패키지 경로를 typeAliases package name 속성값으로 지정
 - mapper resource에 SQL 코드와 매핑 정의를 가지는 XML 파일 목록을 지정
7. application.properties 설정
 - mybatis-config.xml 파일 연결

Closed #22 issue