### PR TITLE
[FE] 모달 컴포넌트 스타일링

### DIFF
--- a/FE/src/components/CardList/Card/ImageSlider.jsx
+++ b/FE/src/components/CardList/Card/ImageSlider.jsx
@@ -3,17 +3,31 @@ import styled from "styled-components";
 
 const ImageSlider = ({ thumbnails }) => {
   return (
-    <div>
+    <ImageWrapper>
       {/* {thumbnails.map((imageUrl, index) => (
         <img key={index} src={imageUrl} alt="숙소 이미지" />
       ))} */}
       <Image src="/" />
-    </div>
+    </ImageWrapper>
   );
 };
 
+const ImageWrapper = styled.div`
+  width: 100%;
+  padding-top: 66.6667%;
+  overflow: hidden;
+  position: relative;
+`;
+
 const Image = styled.img`
-  max-width: 100%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background-color: ${props => props.theme.colors.gray6};
   border-radius: ${props => props.theme.spacings.xxsm};
 `;
 

--- a/FE/src/components/Filter/Filter.jsx
+++ b/FE/src/components/Filter/Filter.jsx
@@ -16,10 +16,8 @@ const Filter = () => {
 };
 
 const Wrapper = styled.div`
+  display: flex;
   padding-top: ${props => props.theme.spacings.unit(12)};
-  ${Button} {
-    margin-right: ${props => props.theme.spacings.xsm};
-  }
 `;
 
 export default Filter;

--- a/FE/src/components/Filter/Guest/Guest.jsx
+++ b/FE/src/components/Filter/Guest/Guest.jsx
@@ -1,8 +1,19 @@
 import React from "react";
+import styled from "styled-components";
 import GuestButton from "./GuestButton";
+import Modal from "./Modal";
 
 const Guest = () => {
-  return <GuestButton />;
+  return (
+    <GuestWrapper>
+      <GuestButton />
+      <Modal />
+    </GuestWrapper>
+  );
 };
+
+const GuestWrapper = styled.div`
+  position: relative;
+`;
 
 export default Guest;

--- a/FE/src/components/Filter/Guest/Guest.jsx
+++ b/FE/src/components/Filter/Guest/Guest.jsx
@@ -9,33 +9,42 @@ import Modal from "./Modal";
 const Guest = () => {
   const guestTypes = [
     {
+      id: 1,
       term: "성인",
       description: "만 13세 이상",
     },
     {
+      id: 2,
       term: "어린이",
       description: "2~12세",
     },
     {
+      id: 3,
       term: "유아",
       description: "2세 미만",
     },
   ];
 
+  const MIN_GUEST_NUM = 0;
+  const MAX_GUEST_NUM = 8;
+
+  // ! 성인, 어린이, 아이 상태에 해당하는 수 로 이후 변경해야 함
+  const GUEST_NUM_TEST = 0;
+
   const modalContent = (
     <ContentsWrapper>
-      {guestTypes.map(({ term, description }) => (
-        <TypeListWrapper>
+      {guestTypes.map(({ id, term, description }) => (
+        <TypeListWrapper key={id}>
           <TextWrapper>
             <Text fontSize="lg">{term}</Text>
             <Text color="gray3">{description}</Text>
           </TextWrapper>
           <ButtonsWrapper>
-            <Button circular bordered>
+            <Button circular bordered disabled={GUEST_NUM_TEST <= MIN_GUEST_NUM}>
               <MdRemove />
             </Button>
-            <GuestNumberText fontSize="lg">0</GuestNumberText>
-            <Button circular bordered>
+            <GuestNumberText fontSize="lg">{GUEST_NUM_TEST}</GuestNumberText>
+            <Button circular bordered disabled={GUEST_NUM_TEST >= MAX_GUEST_NUM}>
               <MdAdd />
             </Button>
           </ButtonsWrapper>

--- a/FE/src/components/Filter/Guest/Guest.jsx
+++ b/FE/src/components/Filter/Guest/Guest.jsx
@@ -1,16 +1,91 @@
 import React from "react";
 import styled from "styled-components";
+import { MdAdd, MdRemove } from "react-icons/md";
+import Text from "Styles/Text";
+import Button from "Styles/Button";
 import GuestButton from "./GuestButton";
 import Modal from "./Modal";
 
 const Guest = () => {
+  const guestTypes = [
+    {
+      term: "성인",
+      description: "만 13세 이상",
+    },
+    {
+      term: "어린이",
+      description: "2~12세",
+    },
+    {
+      term: "유아",
+      description: "2세 미만",
+    },
+  ];
+
+  const modalContent = (
+    <ContentsWrapper>
+      {guestTypes.map(({ term, description }) => (
+        <TypeListWrapper>
+          <TextWrapper>
+            <Text fontSize="lg">{term}</Text>
+            <Text color="gray3">{description}</Text>
+          </TextWrapper>
+          <ButtonsWrapper>
+            <Button circular bordered>
+              <MdRemove />
+            </Button>
+            <GuestNumberText fontSize="lg">0</GuestNumberText>
+            <Button circular bordered>
+              <MdAdd />
+            </Button>
+          </ButtonsWrapper>
+        </TypeListWrapper>
+      ))}
+    </ContentsWrapper>
+  );
+
+  const modalOption = {
+    contents: modalContent,
+    hasContents: false,
+    clearHandler: null,
+    saveHandler: null,
+  };
+
   return (
     <GuestWrapper>
       <GuestButton />
-      <Modal />
+      <Modal options={modalOption} />
     </GuestWrapper>
   );
 };
+
+const TypeListWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ContentsWrapper = styled.div`
+  padding: ${props => props.theme.spacings.xsm} 0;
+
+  ${TypeListWrapper} + ${TypeListWrapper} {
+    padding-top: ${props => props.theme.spacings.lg};
+  }
+`;
+
+const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const ButtonsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const GuestNumberText = styled(Text)`
+  margin: 0 ${props => props.theme.spacings.sm};
+`;
 
 const GuestWrapper = styled.div`
   position: relative;

--- a/FE/src/components/Filter/Guest/GuestButton.jsx
+++ b/FE/src/components/Filter/Guest/GuestButton.jsx
@@ -1,12 +1,26 @@
 import React from "react";
+import styled from "styled-components";
 import Button from "Styles/Button";
 
 const GuestButton = () => {
   return (
-    <Button bordered rounded>
-      Guest
-    </Button>
+    <GButton bordered rounded>
+      게스트
+    </GButton>
   );
 };
+
+const GButton = styled(Button)`
+  &::after {
+    content: "";
+    position: absolute;
+    top: -1px;
+    left: -1px;
+    border: 2px solid ${props => props.theme.colors.black};
+    border-radius: ${props => props.theme.spacings.base};
+    width: calc(100% + 2px);
+    height: calc(100% + 2px);
+  }
+`;
 
 export default GuestButton;

--- a/FE/src/components/Filter/Guest/GuestButton.jsx
+++ b/FE/src/components/Filter/Guest/GuestButton.jsx
@@ -18,6 +18,7 @@ const GButton = styled(Button)`
     left: -1px;
     border: 2px solid ${props => props.theme.colors.black};
     border-radius: ${props => props.theme.spacings.base};
+    background-color: ${props => props.theme.colors.shadow};
     width: calc(100% + 2px);
     height: calc(100% + 2px);
   }

--- a/FE/src/components/Filter/Guest/Modal.jsx
+++ b/FE/src/components/Filter/Guest/Modal.jsx
@@ -1,7 +1,60 @@
 import React from "react";
+import styled, { css } from "styled-components";
+import Button from "Styles/Button";
 
 const Modal = () => {
-  return <div></div>;
+  const SAVE_BUTTON_TEXT = "저장";
+  const CLEAR_BUTTON_TEXT = "지우기";
+
+  return (
+    <ModalWrapper>
+      <ContentsWrapper>
+        <div />
+      </ContentsWrapper>
+      <ButtonsWrapper>
+        <Buttons>
+          <ClearButton highlighted underlined>
+            {CLEAR_BUTTON_TEXT}
+          </ClearButton>
+          <Button secondary>{SAVE_BUTTON_TEXT}</Button>
+        </Buttons>
+      </ButtonsWrapper>
+    </ModalWrapper>
+  );
 };
+
+const ModalWrapper = styled.div`
+  width: 400px;
+  z-index: 10;
+  position: absolute;
+  top: ${props => props.theme.spacings.xl};
+  box-shadow: ${props => props.theme.shadows.xl};
+  background-color: ${props => props.theme.colors.white};
+  border: 1px solid ${props => props.theme.colors.gray5};
+  border-radius: ${props => props.theme.spacings.unit(3)};
+`;
+
+const ContentsWrapper = styled.div`
+  padding: ${props => props.theme.spacings.base};
+  overflow-x: hidden;
+  overflow-y: auto;
+`;
+
+const ButtonsWrapper = styled.div`
+  padding: ${props => props.theme.spacings.sm};
+  border-top: 1px solid ${props => props.theme.colors.gray5};
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const ClearButton = styled(Button)`
+  padding: ${props => props.theme.spacings.xsm};
+  font-size: ${props => props.theme.fontSizes.md};
+  transform: ${props => css`translateX(-${props.theme.spacings.xsm})`};
+`;
 
 export default Modal;

--- a/FE/src/components/Filter/Guest/Modal.jsx
+++ b/FE/src/components/Filter/Guest/Modal.jsx
@@ -2,21 +2,21 @@ import React from "react";
 import styled, { css } from "styled-components";
 import Button from "Styles/Button";
 
-const Modal = () => {
+const Modal = ({ options: { contents = "", hasContents = false, clearHandler = null, saveHandler = null } }) => {
   const SAVE_BUTTON_TEXT = "저장";
   const CLEAR_BUTTON_TEXT = "지우기";
 
   return (
     <ModalWrapper>
-      <ContentsWrapper>
-        <div />
-      </ContentsWrapper>
+      <ContentsWrapper>{contents}</ContentsWrapper>
       <ButtonsWrapper>
         <Buttons>
-          <ClearButton highlighted underlined>
+          <ClearButton highlighted underlined disabled={!hasContents} onClick={clearHandler}>
             {CLEAR_BUTTON_TEXT}
           </ClearButton>
-          <Button secondary>{SAVE_BUTTON_TEXT}</Button>
+          <Button secondary onClick={saveHandler}>
+            {SAVE_BUTTON_TEXT}
+          </Button>
         </Buttons>
       </ButtonsWrapper>
     </ModalWrapper>
@@ -24,7 +24,6 @@ const Modal = () => {
 };
 
 const ModalWrapper = styled.div`
-  width: 400px;
   z-index: 10;
   position: absolute;
   top: ${props => props.theme.spacings.xl};
@@ -35,6 +34,7 @@ const ModalWrapper = styled.div`
 `;
 
 const ContentsWrapper = styled.div`
+  min-width: ${props => props.theme.spacings.unit(80)};
   padding: ${props => props.theme.spacings.base};
   overflow-x: hidden;
   overflow-y: auto;

--- a/FE/src/styles/Button.js
+++ b/FE/src/styles/Button.js
@@ -59,6 +59,7 @@ const Button = styled.button`
     }
     if (props.secondary) {
       return css`
+        padding: ${props.theme.spacings.xsm} ${props.theme.spacings.sm};
         background-color: ${props.theme.colors.black};
         color: ${props.theme.colors.white};
         font-weight: ${props.theme.fontWeights.semiBold};
@@ -79,6 +80,7 @@ const Button = styled.button`
     }
     if (props.underlined) {
       return css`
+        padding: ${props.theme.spacings.xsm} ${props.theme.spacings.sm};
         color: ${props.theme.colors.black};
         text-decoration: underline;
         font-weight: ${props.theme.fontWeights.semiBold};

--- a/FE/src/styles/Button.js
+++ b/FE/src/styles/Button.js
@@ -76,6 +76,7 @@ const Button = styled.button`
         width: ${props.theme.spacings[props.size] || props.theme.spacings.lg};
         height: ${props.theme.spacings[props.size] || props.theme.spacings.lg};
         border-radius: 50%;
+        line-height: 0;
       `;
     }
     if (props.underlined) {

--- a/FE/src/styles/theme.js
+++ b/FE/src/styles/theme.js
@@ -45,7 +45,7 @@ const fontWeights = {
 
 const shadows = {
   xxl: "0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22)",
-  xl: "0 14px 28px rgba(0,0,0,0.25), 0 10px 10px rgba(0,0,0,0.22)",
+  xl: "0px 10px 37px rgba(0, 0, 0, 0.15)",
   lg: "0 2px 8px rgba(0,0,0,0.24)",
   md: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24)",
   sm: "0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)",

--- a/FE/src/styles/theme.js
+++ b/FE/src/styles/theme.js
@@ -18,6 +18,7 @@ const colors = {
   gray5: "#DDDDDD",
   gray6: "#F7F7F7",
   white: "#FFFFFF",
+  shadow: "rgba(0, 0, 0, 0.05)",
 };
 
 const fontSizes = {


### PR DESCRIPTION
## 구현 내용

- Close #16 
- #16 이슈와는 다른 이슈지만, 숙소 이미지 사이즈를 고정하는 스타일 코드를 추가로 작성했습니다.
- 공통적으로 사용할 모달 컴포넌트, 그리고 게스트 모달을 스타일링 했습니다.
- 동작은 아직 안됩니다. 컴포넌트와 리듀서가 연결돼야 제대로 동작합니다.
- 현재 Guest 폴더 내부 파일을 수정했습니다. 작업하다보니 현재 Date/Guest/Price 구조 말고 다른 방식으로 폴더 구조 변경이 필요할 거 같아요. Modal을 밖으로 빼서 재사용하는 컴포넌트로 만들고, 필터 버튼과 해당하는 모달을 map으로 뿌려주는 형식으로 한다던가.. 하는 식으로 중복을 줄일 수 있을 거 같아요.
- 코드 확인해보시고 모르는 부분 있으면 코멘트로 꼭 남겨주세요.
