### PR TITLE
[FE] 필터 버튼 클릭 이벤트 중첩 버그 수정

### DIFF
--- a/FE/src/customHooks/useOutsideClick.jsx
+++ b/FE/src/customHooks/useOutsideClick.jsx
@@ -6,9 +6,9 @@ const useOutsideClick = (ref, clickHandler) => {
   };
 
   useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("click", handleClickOutside);
     return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("click", handleClickOutside);
     };
   }, [ref]);
 };


### PR DESCRIPTION
## 구현 내용

- mousedown 이벤트가 먼저 일어나면서 state가 2번 수정, 모달이 깜빡이는 현상이 발생했다.
- click 이벤트로 이벤트를 변경하니 제대로 동작함.
- Close #45 