### PR TITLE
[FE] 필터링 api 요청 로직 추가 및 리팩토링

### DIFF
--- a/FE/.gitignore
+++ b/FE/.gitignore
@@ -19,5 +19,6 @@ thumb
 sketch
 
 dist
+.env
 
 # End of https://www.gitignore.io/api/react

--- a/FE/package.json
+++ b/FE/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^0.19.2",
+    "dotenv-webpack": "^1.8.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-icons": "^3.10.0",

--- a/FE/src/components/CardList/Card/ImageSlider.jsx
+++ b/FE/src/components/CardList/Card/ImageSlider.jsx
@@ -7,7 +7,7 @@ const ImageSlider = ({ thumbnails }) => {
       {/* {thumbnails.map((imageUrl, index) => (
         <img key={index} src={imageUrl} alt="숙소 이미지" />
       ))} */}
-      <Image src="/" />
+      <Image src={thumbnails[0]} />
     </ImageWrapper>
   );
 };

--- a/FE/src/components/CardList/CardList.jsx
+++ b/FE/src/components/CardList/CardList.jsx
@@ -10,7 +10,7 @@ const CardList = () => {
   const { cardList, cardListDispatch } = useContext(CardListContext);
 
   const { loading, errorMsg } = useFetch({
-    url: "http://3.34.15.148/api/listing",
+    url: `${process.env.API_KEY}`,
     dispatch: cardListDispatch,
     actionType: {
       success: fetchActions.FETCH_SUCCESS,

--- a/FE/src/components/CardList/CardList.jsx
+++ b/FE/src/components/CardList/CardList.jsx
@@ -7,11 +7,11 @@ import Title from "./Title";
 import Card from "./Card/Card";
 
 const CardList = () => {
-  const { cardList, dispatch } = useContext(CardListContext);
+  const { cardList, cardListDispatch } = useContext(CardListContext);
 
   const { loading, errorMsg } = useFetch({
     url: "http://3.34.15.148/api/listing",
-    dispatch,
+    dispatch: cardListDispatch,
     actionType: {
       success: fetchActions.FETCH_SUCCESS,
       error: fetchActions.FETCH_ERROR,

--- a/FE/src/components/Filter/Filter.jsx
+++ b/FE/src/components/Filter/Filter.jsx
@@ -17,11 +17,11 @@ const Filter = () => {
   const { checkin, checkout, adults, children, infants, priceMin, priceMax } = queries;
 
   // Todo:
-  // ! 초기 런더링시 필터 요청 보내지 않도록 처리
   // ! queries가 같을 때 재요청을 보내지 않도록 처리
   // ! useFetch 사용 여부 확인
 
   useEffect(() => {
+    if (queries === filterInitialState) return;
     const getData = async () => {
       const url = `http://3.34.15.148/api/listing/search?checkin=${checkin}&checkout=${checkout}&adults=${adults}&children=${children}&infants=${infants}&priceMin=${priceMin}&priceMax=${priceMax}`;
       const { data } = await axios.get(url);

--- a/FE/src/components/Filter/Filter.jsx
+++ b/FE/src/components/Filter/Filter.jsx
@@ -19,7 +19,7 @@ const Filter = () => {
   const isValidRequest = !(isSameValue(queries, filterInitialState) || isSameObject(queries, previousQueries));
 
   const fetchOptions = {
-    url: `http://3.34.15.148/api/listing/search?checkin=${checkin}&checkout=${checkout}&adults=${adults}&children=${children}&infants=${infants}&priceMin=${priceMin}&priceMax=${priceMax}`,
+    url: `${process.env.API_KEY}/search?checkin=${checkin}&checkout=${checkout}&adults=${adults}&children=${children}&infants=${infants}&priceMin=${priceMin}&priceMax=${priceMax}`,
     dispatch: cardListDispatch,
     actionType: { success: fetchActions.FETCH_SUCCESS },
     state: queries,

--- a/FE/src/components/Filter/Filter.jsx
+++ b/FE/src/components/Filter/Filter.jsx
@@ -1,10 +1,11 @@
-import React, { useContext, useEffect } from "react";
-import axios from "axios";
+import React, { useContext } from "react";
 import { filterInitialState } from "InitialStates/initialStates";
 import { FilterContext } from "Contexts/filterContext";
 import { CardListContext } from "Contexts/cardListContext";
 import { fetchActions, filterActions } from "Actions/actions";
+import { isSameObject, isSameValue } from "Utils/utils";
 import useFetch from "CustomHooks/useFetch";
+import usePrevious from "CustomHooks/usePrevious";
 import styled from "styled-components";
 import Date from "./Date/Date";
 import Guest from "./Guest/Guest";
@@ -13,22 +14,19 @@ import Price from "./Price/Price";
 const Filter = () => {
   const { queries, filterDispatch } = useContext(FilterContext);
   const { cardListDispatch } = useContext(CardListContext);
-
   const { checkin, checkout, adults, children, infants, priceMin, priceMax } = queries;
+  const previousQueries = usePrevious(queries);
+  const isValidRequest = !(isSameValue(queries, filterInitialState) || isSameObject(queries, previousQueries));
 
-  // Todo:
-  // ! queries가 같을 때 재요청을 보내지 않도록 처리
-  // ! useFetch 사용 여부 확인
+  const fetchOptions = {
+    url: `http://3.34.15.148/api/listing/search?checkin=${checkin}&checkout=${checkout}&adults=${adults}&children=${children}&infants=${infants}&priceMin=${priceMin}&priceMax=${priceMax}`,
+    dispatch: cardListDispatch,
+    actionType: { success: fetchActions.FETCH_SUCCESS },
+    state: queries,
+    isValidRequest,
+  };
 
-  useEffect(() => {
-    if (queries === filterInitialState) return;
-    const getData = async () => {
-      const url = `http://3.34.15.148/api/listing/search?checkin=${checkin}&checkout=${checkout}&adults=${adults}&children=${children}&infants=${infants}&priceMin=${priceMin}&priceMax=${priceMax}`;
-      const { data } = await axios.get(url);
-      cardListDispatch({ type: fetchActions.FETCH_SUCCESS, payload: data });
-    };
-    getData();
-  }, [queries]);
+  useFetch(fetchOptions);
 
   const filterByGuest = payload => filterDispatch({ type: filterActions.FILTER_BY_GUEST, payload });
 

--- a/FE/src/components/Filter/Filter.jsx
+++ b/FE/src/components/Filter/Filter.jsx
@@ -1,6 +1,10 @@
 import React, { useContext, useEffect } from "react";
+import axios from "axios";
+import { filterInitialState } from "InitialStates/initialStates";
 import { FilterContext } from "Contexts/filterContext";
-import { filterActions } from "Actions/actions";
+import { CardListContext } from "Contexts/cardListContext";
+import { fetchActions, filterActions } from "Actions/actions";
+import useFetch from "CustomHooks/useFetch";
 import styled from "styled-components";
 import Date from "./Date/Date";
 import Guest from "./Guest/Guest";
@@ -8,11 +12,22 @@ import Price from "./Price/Price";
 
 const Filter = () => {
   const { queries, filterDispatch } = useContext(FilterContext);
+  const { cardListDispatch } = useContext(CardListContext);
 
-  // ! useFetch Test
-  // ! queries가 같을 때 재 요청을 보내지 않도록
+  const { checkin, checkout, adults, children, infants, priceMin, priceMax } = queries;
+
+  // Todo:
+  // ! 초기 런더링시 필터 요청 보내지 않도록 처리
+  // ! queries가 같을 때 재요청을 보내지 않도록 처리
+  // ! useFetch 사용 여부 확인
+
   useEffect(() => {
-    console.log(queries);
+    const getData = async () => {
+      const url = `http://3.34.15.148/api/listing/search?checkin=${checkin}&checkout=${checkout}&adults=${adults}&children=${children}&infants=${infants}&priceMin=${priceMin}&priceMax=${priceMax}`;
+      const { data } = await axios.get(url);
+      cardListDispatch({ type: fetchActions.FETCH_SUCCESS, payload: data });
+    };
+    getData();
   }, [queries]);
 
   const filterByGuest = payload => filterDispatch({ type: filterActions.FILTER_BY_GUEST, payload });

--- a/FE/src/contexts/cardListContext.jsx
+++ b/FE/src/contexts/cardListContext.jsx
@@ -5,14 +5,14 @@ import { cardListInitialState } from "InitialStates/initialStates";
 const CardListContext = createContext();
 
 const CardListProvider = ({ children }) => {
-  const [cardList, dispatch] = useReducer(reducer, cardListInitialState);
+  const [cardList, cardListDispatch] = useReducer(reducer, cardListInitialState);
 
   const contextValue = useMemo(
     () => ({
       cardList,
-      dispatch,
+      cardListDispatch,
     }),
-    [cardList, dispatch],
+    [cardList, cardListDispatch],
   );
 
   return <CardListContext.Provider value={contextValue}>{children}</CardListContext.Provider>;

--- a/FE/src/customHooks/useFetch.jsx
+++ b/FE/src/customHooks/useFetch.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 
-const useFetch = ({ url, dispatch, actionType: { success, error } }) => {
+const useFetch = ({ url, dispatch, actionType: { success, error }, state = null, isValidRequest = true }) => {
   const [loading, setLoading] = useState(true);
   const [errorMsg, setErrorMsg] = useState(null);
 
@@ -17,8 +17,9 @@ const useFetch = ({ url, dispatch, actionType: { success, error } }) => {
   };
 
   useEffect(() => {
+    if (!isValidRequest) return;
     getData();
-  }, []);
+  }, [state]);
 
   return { loading, errorMsg };
 };

--- a/FE/src/customHooks/usePrevious.jsx
+++ b/FE/src/customHooks/usePrevious.jsx
@@ -1,0 +1,11 @@
+import { useRef, useEffect } from "react";
+
+const usePrevious = value => {
+  const ref = useRef();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+};
+
+export default usePrevious;

--- a/FE/src/initialStates/initialStates.js
+++ b/FE/src/initialStates/initialStates.js
@@ -12,6 +12,6 @@ export const filterInitialState = {
   adults: 0,
   children: 0,
   infants: 0,
-  priceMin: 0,
-  priceMax: 0,
+  priceMin: "",
+  priceMax: "",
 };

--- a/FE/src/reducers/cardReducer.jsx
+++ b/FE/src/reducers/cardReducer.jsx
@@ -6,7 +6,7 @@ const cardReducer = (state, action) => {
 
   switch (type) {
     case FETCH_SUCCESS:
-      return [...state, ...payload];
+      return [...payload];
     case FETCH_ERROR:
       return [...state];
     default:

--- a/FE/src/utils/utils.js
+++ b/FE/src/utils/utils.js
@@ -1,0 +1,2 @@
+export const isSameObject = (value, other) => JSON.stringify(value) === JSON.stringify(other);
+export const isSameValue = (value, other) => value === other;

--- a/FE/tsconfig.json
+++ b/FE/tsconfig.json
@@ -49,7 +49,8 @@
       "Contexts*": ["contexts*"],
       "Reducers*": ["reducers*"],
       "CustomHooks*": ["customHooks*"],
-      "InitialStates*": ["initialStates*"]
+      "InitialStates*": ["initialStates*"],
+      "Utils*": ["utils*"]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */

--- a/FE/webpack.common.js
+++ b/FE/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const Dotenv = require("dotenv-webpack");
 
 module.exports = {
   entry: "./src/index.jsx",
@@ -51,5 +52,6 @@ module.exports = {
       filename: "index.html",
       template: "public/index.html",
     }),
+    new Dotenv(),
   ],
 };

--- a/FE/webpack.common.js
+++ b/FE/webpack.common.js
@@ -41,6 +41,7 @@ module.exports = {
       Contexts: path.resolve(__dirname, "./src/contexts/"),
       CustomHooks: path.resolve(__dirname, "./src/customHooks/"),
       InitialStates: path.resolve(__dirname, "./src/initialStates/"),
+      Utils: path.resolve(__dirname, "./src/utils/"),
     },
     extensions: [".js", ".jsx", ".ts", ".tsx"],
   },

--- a/FE/yarn.lock
+++ b/FE/yarn.lock
@@ -2514,6 +2514,25 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
+dotenv-defaults@^1.0.2:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz#032c024f4b5906d9990eb06d722dc74cc60ec1bd"
+  integrity sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==
+  dependencies:
+    dotenv "^6.2.0"
+
+dotenv-webpack@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz#7ca79cef2497dd4079d43e81e0796bc9d0f68a5e"
+  integrity sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==
+  dependencies:
+    dotenv-defaults "^1.0.2"
+
+dotenv@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
+  integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"


### PR DESCRIPTION
## 구현 내용

- Guest Filter 상태 변경시 필터링 api 요청 보내고 카드 리스트 업데이트하는 기능 구현
- api 요청시 예외처리 로직 구현
    > - 최초 렌더링 시에는 필터링 api 요청 보내지 않음
    > - 이전 상태값과 현재 상태값이 동일할 경우 api 요청 보내지 않음
- useFetch 수정 및 util 함수 추가
- dotenv-webpack을 사용하여 환경변수 셋업 -> api를 환경변수에 할당하여 사용하도록 리팩토링

---

Close #48 
Close #49 